### PR TITLE
Caddy: Do Not Stop Processing Middleware on Preflight

### DIFF
--- a/caddy/corsPlugin.go
+++ b/caddy/corsPlugin.go
@@ -33,9 +33,6 @@ func setup(c *caddy.Controller) error {
 			for _, rule := range rules {
 				if httpserver.Path(r.URL.Path).Matches(rule.Path) {
 					rule.Conf.HandleRequest(w, r)
-					if cors.IsPreflight(r) {
-						return 200, nil
-					}
 					break
 				}
 			}


### PR DESCRIPTION
The current Caddy plugin stops processing additional middleware if the request is considered to be a preflight request. This prevents additional Caddyfile directives from being applied. For example, consider the following Caddyfile:

``` yaml
localhost:80
cors
header / {
      -Server
}
proxy / localhost:5000
```

Without the PR, the `Server` header is not removed from requests (e.g. `Server: caddy`), because the of the short-circuit. After the PR, additional directives are honored and the `Server` header is properly removed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/captncraig/cors/7)

<!-- Reviewable:end -->
