### PR TITLE
Make CORS safer by not reflecting origin for *

### DIFF
--- a/caddy/corsPlugin.go
+++ b/caddy/corsPlugin.go
@@ -1,10 +1,11 @@
 package caddy
 
 import (
-	"github.com/captncraig/cors"
 	"net/http"
 	"strconv"
 	"strings"
+
+	"github.com/captncraig/cors"
 
 	"github.com/mholt/caddy"
 	"github.com/mholt/caddy/caddyhttp/httpserver"

--- a/cors.go
+++ b/cors.go
@@ -50,7 +50,11 @@ func (c *Config) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	//check origin against allowed origins
 	for _, ao := range c.AllowedOrigins {
 		if ao == "*" || ao == requestOrigin {
-			w.Header().Set(allowOriginKey, requestOrigin)
+			responseOrigin := "*"
+			if ao != "*" {
+				responseOrigin = requestOrigin
+			}
+			w.Header().Set(allowOriginKey, responseOrigin)
 			w.Header().Add(varyKey, originKey)
 			break
 		}

--- a/cors_test.go
+++ b/cors_test.go
@@ -25,8 +25,8 @@ func TestDefault_Origin_Supplied(t *testing.T) {
 	w, r := getReq("OPTIONS")
 	r.Header.Set(originKey, "http://bar.com")
 	Default().HandleRequest(w, r)
-	if w.Header().Get(allowOriginKey) != "http://bar.com" {
-		t.Fatalf("Expect origin of \"http://bar.com\". Got \"%s\".", w.Header().Get(allowOriginKey))
+	if w.Header().Get(allowOriginKey) != "*" {
+		t.Fatalf("Expect origin of \"*\". Got \"%s\".", w.Header().Get(allowOriginKey))
 	}
 	if w.Header().Get(varyKey) != "Origin" {
 		t.Fatal("Must include Vary:Origin if allow origin header set to specific domain.")


### PR DESCRIPTION
This seems like it's small and nit-picky, but I think it
is pretty unexpected for someone using this to set a policy
of ACAO * and have the Origin reflected, and it has big security
implications as well.