### PR TITLE
If allowed headers is * returns requested headers instead of *

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -67,7 +67,12 @@ func (c *Config) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	if IsPreflight(r) {
 		w.Header().Set(allowMethodsKey, c.AllowedMethods)
 		if c.AllowedHeaders != "" {
-			w.Header().Set(allowHeadersKey, c.AllowedHeaders)
+			if c.AllowedHeaders != "*" {
+				w.Header().Set(allowHeadersKey, c.AllowedHeaders)
+			} else {
+				w.Header().Set(allowHeadersKey, r.Header.Get(requestHeadersKey))
+			}
+
 		}
 		if c.MaxAge > 0 {
 			w.Header().Set(maxAgeKey, fmt.Sprint(c.MaxAge))

--- a/cors_test.go
+++ b/cors_test.go
@@ -53,3 +53,16 @@ func TestDefault_Methods(t *testing.T) {
 		t.Fatal("Allow methods should be set")
 	}
 }
+
+func TestDefault_AllowAllHeaders(t *testing.T) {
+	w, r := getReq("OPTIONS")
+	c := Default()
+	c.AllowedHeaders = "*"
+	reqHeaders := "Bar, Foo, X-Yz"
+	r.Header.Set(originKey, "http://bar.com")
+	r.Header.Set(requestHeadersKey, reqHeaders)
+	c.HandleRequest(w, r)
+	if w.Header().Get(allowHeadersKey) != reqHeaders {
+		t.Fatal("If AllowedHeaders is *, it should copy the value of requestHeadersKey to allowHeadersKey")
+	}
+}


### PR DESCRIPTION
Even though the standard allows us to use `*` in `Access-Control-Allow-Headers`, most clients seem not to support this.

The way to actually allow any header, is to set `Access-Control-Allow-Headers` to match `Access-Control-Request-Headers` and this PR reflects this.

Hope it's worthy of a merge.