### PR TITLE
Add a configuration label to match origins against a regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ cors [path] [domains...] {
 *   **path** is the file or directory this applies to (default is /).
 *   **domains** is a space-seperated list of domains to allow. If ommitted, all domains will be granted access.
 *   **origin** is a domain to grant access to. May be specified multiple times or ommitted.
-*   **origin_regexp** is a regexp that will be matched to the `Origin` header. Access will be granted accordingly. It can be used in conjonction with the `origin` config (executed as a fallback to `origin`).
+*   **origin_regexp** is a regexp that will be matched to the `Origin` header. Access will be granted accordingly. It can be used in conjonction with the `origin` config (executed as a fallback to `origin`). May be specified multiple times or ommitted.
 *   **methods** is set of http methods to allow. Default is these: POST,GET,OPTIONS,PUT,DELETE.
 *   **allow_credentials** sets the value of the Access-Control-Allow-Credentials header. Can be true or false. By default, header will not be included.
 *   **max_age** is the length of time in seconds to cache preflight info. Not set by default.
@@ -43,7 +43,7 @@ Full configuration:
 cors / {
   origin            http://allowedSite.com
   origin            http://anotherSite.org https://anotherSite.org
-  origin_regex      anotherSite\.com$
+  origin_regexp     .+\.example\.com$
   methods           POST,PUT
   allow_credentials false
   max_age           3600

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ It allows you to whitelist particular domains per route, or to simply allow all 
 ```
 cors [path] [domains...] {
 	origin            [origin]
+	origin_regexp     [regexp]
 	methods           [methods]
 	allow_credentials [allowCredentials]
 	max_age           [maxAge]
@@ -19,6 +20,7 @@ cors [path] [domains...] {
 *   **path** is the file or directory this applies to (default is /).
 *   **domains** is a space-seperated list of domains to allow. If ommitted, all domains will be granted access.
 *   **origin** is a domain to grant access to. May be specified multiple times or ommitted.
+*   **origin_regexp** is a regexp that will be matched to the `Origin` header. Access will be granted accordingly. It can be used in conjonction with the `origin` config (executed as a fallback to `origin`).
 *   **methods** is set of http methods to allow. Default is these: POST,GET,OPTIONS,PUT,DELETE.
 *   **allow_credentials** sets the value of the Access-Control-Allow-Credentials header. Can be true or false. By default, header will not be included.
 *   **max_age** is the length of time in seconds to cache preflight info. Not set by default.
@@ -41,6 +43,7 @@ Full configuration:
 cors / {
   origin            http://allowedSite.com
   origin            http://anotherSite.org https://anotherSite.org
+  origin_regex      anotherSite\.com$
   methods           POST,PUT
   allow_credentials false
   max_age           3600

--- a/caddy/corsPlugin.go
+++ b/caddy/corsPlugin.go
@@ -86,6 +86,11 @@ func parseRules(c *caddy.Controller) ([]*corsRule, error) {
 						return nil, c.Errf("could no compile regexp: %s", err)
 					}
 
+					if !anyOrigins {
+						rule.Conf.AllowedOrigins = nil
+						anyOrigins = true
+					}
+
 					rule.Conf.OriginRegexps = append(rule.Conf.OriginRegexps, r)
 				}
 			case "methods":

--- a/caddy/corsPlugin.go
+++ b/caddy/corsPlugin.go
@@ -86,7 +86,7 @@ func parseRules(c *caddy.Controller) ([]*corsRule, error) {
 						return nil, c.Errf("could no compile regexp: %s", err)
 					}
 
-					rule.Conf.OriginRegexp = r
+					rule.Conf.OriginRegexps = append(rule.Conf.OriginRegexps, r)
 				}
 			case "methods":
 				if arg, err := singleArg(c, "methods"); err != nil {

--- a/caddy/corsPlugin.go
+++ b/caddy/corsPlugin.go
@@ -2,6 +2,7 @@ package caddy
 
 import (
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -75,6 +76,18 @@ func parseRules(c *caddy.Controller) ([]*corsRule, error) {
 					rule.Conf.AllowedOrigins = append(rule.Conf.AllowedOrigins, strings.Split(domain, ",")...)
 				}
 				anyOrigins = true
+			case "origin_regexp":
+				if arg, err := singleArg(c, "origin_regexp"); err != nil {
+					return nil, err
+				} else {
+					r, err := regexp.Compile(arg)
+
+					if err != nil {
+						return nil, c.Errf("could no compile regexp: %s", err)
+					}
+
+					rule.Conf.OriginRegexp = r
+				}
 			case "methods":
 				if arg, err := singleArg(c, "methods"); err != nil {
 					return nil, err

--- a/cors_test.go
+++ b/cors_test.go
@@ -46,15 +46,24 @@ func TestDefault_Dissallowed_Origin(t *testing.T) {
 }
 
 func TestDefault_Allowed_Origin_By_Regexp(t *testing.T) {
-	w, r := getReq("OPTIONS")
 	c := Default()
 	c.AllowedOrigins = []string{}
-	c.OriginRegexp = regexp.MustCompile("^http\\:\\/\\/(.*)\\.bar")
-	r.Header.Set(originKey, "http://foo.bar.com")
-	c.HandleRequest(w, r)
-	if w.Header().Get(allowOriginKey) != "http://foo.bar.com" {
-		t.Fatal("Should have origin header with the request origin when the regexp matches")
+	c.OriginRegexps = []*regexp.Regexp{
+		regexp.MustCompile(".+\\.example\\.com$"),
+		regexp.MustCompile("^http\\:\\/\\/(.+)\\.other\\.org$"),
 	}
+
+	allowedOrigins := []string{"http://foo.example.com", "http://bar.other.org"}
+
+	for _, origin := range allowedOrigins {
+		w, r := getReq("OPTIONS")
+		r.Header.Set(originKey, origin)
+		c.HandleRequest(w, r)
+		if w.Header().Get(allowOriginKey) != origin {
+			t.Fatal("Should have origin header with the request origin when the regexp matches")
+		}
+	}
+
 }
 
 func TestDefault_Methods(t *testing.T) {

--- a/cors_test.go
+++ b/cors_test.go
@@ -3,6 +3,7 @@ package cors
 import (
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"testing"
 )
 
@@ -41,6 +42,18 @@ func TestDefault_Dissallowed_Origin(t *testing.T) {
 	c.HandleRequest(w, r)
 	if w.Header().Get(allowOriginKey) != "" {
 		t.Fatal("Should not have origin header when no origin not explicitely allowed")
+	}
+}
+
+func TestDefault_Allowed_Origin_By_Regexp(t *testing.T) {
+	w, r := getReq("OPTIONS")
+	c := Default()
+	c.AllowedOrigins = []string{}
+	c.OriginRegexp = regexp.MustCompile("^http\\:\\/\\/(.*)\\.bar")
+	r.Header.Set(originKey, "http://foo.bar.com")
+	c.HandleRequest(w, r)
+	if w.Header().Get(allowOriginKey) != "http://foo.bar.com" {
+		t.Fatal("Should have origin header with the request origin when the regexp matches")
 	}
 }
 


### PR DESCRIPTION
This PR add a new label to allow origins with a regexp.

It can be useful to allow subdomains.

Example:
```
cors / {
  origin_regex      allowedSite\.com$
}
```